### PR TITLE
Add setup script and dev guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Development Guidelines
+
+- Run `bash ./codex_setup.sh` to set up the dev environment if `DEV_ENV_BUILT` is not set or tools like `pre-commit` or `pytest` are missing.
+- Use `pre-commit run --files <changed files>` to format and lint code.
+- Execute `pytest` to run the test suite.
+- Keep commit messages short and descriptive.

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exit if environment already built
+if [ "${DEV_ENV_BUILT:-}" = "1" ]; then
+    echo "Development environment already built."
+    exit 0
+fi
+
+# Ensure running from repository root
+cd "$(dirname "$0")"
+
+# Ensure uv is installed
+if ! command -v uv >/dev/null 2>&1; then
+    if command -v pip >/dev/null 2>&1; then
+        pip install --user uv || echo "# TODO: install uv"
+        export PATH="$HOME/.local/bin:$PATH"
+    else
+        echo "# TODO: install uv (pip not found)"
+    fi
+fi
+
+# Create virtual environment
+if [ ! -d .venv ]; then
+    uv venv .venv
+fi
+
+# Install dependencies from uv.lock and project in editable mode
+uv sync
+source .venv/bin/activate
+uv pip install -e .
+deactivate
+
+# Mark environment as built
+export DEV_ENV_BUILT=1
+echo 'export DEV_ENV_BUILT=1' >> "$HOME/.profile"


### PR DESCRIPTION
## Summary
- add `codex_setup.sh` to create a virtual environment using uv
- document development rules in `AGENTS.md`

## Testing
- `pre-commit run --files codex_setup.sh AGENTS.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_i_684186b4146083279443a9fc39a061f5